### PR TITLE
Forcing fingerprinting to use eth1

### DIFF
--- a/nomad/nomad-client.json
+++ b/nomad/nomad-client.json
@@ -8,6 +8,7 @@
   "log_level": "INFO",
   "client": {
     "enabled": true,
+    "network_interface": "eth1",
     "servers": [ "10.7.0.10:4647" ]
   }
 }


### PR DESCRIPTION
This should make the docker driver use eth1 for port forwarding.
